### PR TITLE
nitropad-CI: easy to maintain - automatic build & upload-files

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,6 +2,7 @@ include: 'https://raw.githubusercontent.com/Nitrokey/common-ci-jobs/master/commo
 
 stages:
   - pull-github
+  - build 
   - deploy
 
 variables:
@@ -12,5 +13,28 @@ variables:
   REPO_USER: nitrokey
   REPO_NAME: ubuntu-oem
   MAIN_BRANCH: nitropad
-  ENABLE_OEM: "true"
+  COMMON_PULL: "true"
+  COMMON_UPLOAD_NIGHTLY: "false"
+  COMMON_GITHUB_RELEASE: "false"
+  COMMON_UPLOAD_FILES: "true"
+  DEVICE_FOLDER: "nitropad"
+  UPLOAD_FOLDER: "ubuntu-oem"
 
+oem-build:
+  image: ghcr.io/lennardboediger/ci-oem-release:latest
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "push"'
+  tags:
+    - docker
+  stage: build
+  script:
+    - ./make-image.sh
+    - ls
+    - mkdir -p artifacts
+    - cp *nitrokey*.iso artifacts/
+  after_script:
+    - wget $icon_server/checkmark/$CI_COMMIT_REF_NAME/$CI_COMMIT_SHA/$CI_JOB_NAME/$CI_JOB_STATUS/${CI_JOB_URL#*/*/*/}
+  artifacts:
+    paths:
+      - artifacts
+    expire_in: 1 hrs


### PR DESCRIPTION
automatic build & upload-files
All Test passed
pull: skip
build & upload: https://git.dotplex.com/nitrokey/ubuntu-oem/-/pipelines/14487
Upload to: https://www.nitrokey.com/files/ci/nitropad/ubuntu-oem/